### PR TITLE
Update cursor mode when a new machine is selected

### DIFF
--- a/Release Files/Release history.txt
+++ b/Release Files/Release history.txt
@@ -4,7 +4,7 @@ This can be done manually or via Options > Configuration > Reset To Default Sett
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Version 1.41 - 23/01/2025 (by Paul Farrow and John Stroebel)
+Version 1.41 - 24/01/2025 (by Paul Farrow and John Stroebel)
 * Bug fixes:
   - If a hardware generated ZX81 HSync pulse is output part way through a scanline then it is no
     longer interpreted as starting a new scanline.

--- a/Source/DebugWin/Profiler.h
+++ b/Source/DebugWin/Profiler.h
@@ -10,7 +10,7 @@
 #include <ComCtrls.hpp>
 #include <ExtCtrls.hpp>
 #include <vector>
-#include <z80.h>
+#include "z80.h"
 
 //---------------------------------------------------------------------------
 class TProfiler : public TForm

--- a/Source/zx81config.h
+++ b/Source/zx81config.h
@@ -410,8 +410,6 @@ extern const char* temporaryFolder;
 extern const char* romsFolder;
 extern const char* nvMemoryFolder;
 extern const char* documentationFolder;
-extern const char* examplesDisksFolder;
-extern const char* examplesDrivesFolder;
 extern const char* exampleZX81ProgramsFolder;
 extern const char* exampleSpectrumProgramsFolder;
 extern const char* fdcRomsFolder;


### PR DESCRIPTION
This facilitates using the Lambda cursor keys when necessary versus switching them manually. Also, one might expect the cursor mode to change when selecting a new machine.